### PR TITLE
move `events` & `errors` to interface

### DIFF
--- a/src/interfaces/IStUSD.sol
+++ b/src/interfaces/IStUSD.sol
@@ -28,6 +28,99 @@ interface IStUSD {
     /// @notice Zero amount
     error ZeroAmount();
 
+    // =================== Struct ====================
+
+    /**
+     * @notice Redemption state for account
+     * @param pending Pending redemption amount
+     * @param withdrawn Withdrawn redemption amount
+     * @param redemptionQueueTarget Target in vault's redemption queue
+     */
+    struct Redemption {
+        uint256 pending;
+        uint256 withdrawn;
+        uint256 redemptionQueueTarget;
+    }
+
+    /**
+     * @notice Fee type
+     */
+    enum FeeType {
+        Mint,
+        Redeem,
+        Performance
+    }
+
+    // =================== Events ===================
+
+    /**
+     * @notice Emitted when LP tokens are redeemed
+     * @param account Redeeming account
+     * @param shares Amount of LP tokens burned
+     * @param amount Amount of underlying tokens
+     */
+    event Redeemed(address indexed account, uint256 shares, uint256 amount);
+
+    /**
+     * @notice Emitted when redeemed underlying tokens are withdrawn
+     * @param account Withdrawing account
+     * @param amount Amount of underlying tokens withdrawn
+     */
+    event Withdrawn(address indexed account, uint256 amount);
+
+    /**
+     * @notice Emitted when USDC is deposited into a Bloom Pool
+     * @param tby TBY address
+     * @param amount Amount of TBY deposited
+     */
+    event TBYAutoMinted(address indexed tby, uint256 amount);
+
+    /**
+     * @notice Emitted when someone corrects the remaining balance
+     * using the poke function
+     * @param amount The updated remaining balance
+     */
+    event RemainingBalanceAdjusted(uint256 amount);
+
+    /**
+     * @notice Emitted when a fee is captured and sent to the Stakeup Staking
+     * @param feeType Fee type
+     * @param shares Number of stUSD shares sent to the Stakeup Staking
+     */
+    event FeeCaptured(FeeType feeType, uint256 shares);
+
+    /**
+     * @notice An executed shares transfer from `sender` to `recipient`.
+     * @dev emitted in pair with an ERC20-defined `Transfer` event.
+     * @param from Address of the sender
+     * @param to Address of the recipient
+     * @param sharesAmount Amount of shares transferred 
+     */
+    event TransferShares(address indexed from, address indexed to, uint256 sharesAmount);
+
+    /**
+     * @notice An executed `burnShares` request
+     * @dev Reports simultaneously burnt shares amount
+     * and corresponding stUSD amount.
+     * The stUSD amount is calculated twice: before and after the burning incurred rebase.
+     * @param account holder of the burnt shares
+     * @param preRebaseTokenAmount amount of stUSD the burnt shares corresponded to before the burn
+     * @param postRebaseTokenAmount amount of stUSD the burnt shares corresponded to after the burn
+     * @param sharesAmount amount of burnt shares
+    */
+    event SharesBurnt(
+        address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount
+    );
+
+    /**
+     * @notice Emitted when user deposits
+     * @param account User address
+     * @param token Address of the token being deposited
+     * @param amount Amount of tokens deposited
+     * @param shares Amount of shares minted to the user
+     */
+    event Deposit(address indexed account, address token, uint256 amount, uint256 shares);
+
     function getUsdByShares(uint256 _sharesAmount) external view returns (uint256);
 
     function getSharesByUsd(uint256 _usdAmount) external view returns (uint256);

--- a/src/token/StUSD.sol
+++ b/src/token/StUSD.sol
@@ -21,29 +21,6 @@ contract StUSD is StUSDBase, ReentrancyGuard {
     using SafeERC20 for IERC20;
     using SafeERC20 for IWstUSD;
 
-    // =================== Struct ====================
-
-    /**
-     * @notice Redemption state for account
-     * @param pending Pending redemption amount
-     * @param withdrawn Withdrawn redemption amount
-     * @param redemptionQueueTarget Target in vault's redemption queue
-     */
-    struct Redemption {
-        uint256 pending;
-        uint256 withdrawn;
-        uint256 redemptionQueueTarget;
-    }
-
-    /**
-     * @notice Fee type
-     */
-    enum FeeType {
-        Mint,
-        Redeem,
-        Performance
-    }
-
     // =================== Storage ===================
 
     /// @notice WstUSD token
@@ -99,43 +76,7 @@ contract StUSD is StUSDBase, ReentrancyGuard {
     /// @dev Remaining underlying token balance
     uint256 internal _remainingBalance;
 
-    // =================== Events ===================
 
-    /**
-     * @notice Emitted when LP tokens are redeemed
-     * @param account Redeeming account
-     * @param shares Amount of LP tokens burned
-     * @param amount Amount of underlying tokens
-     */
-    event Redeemed(address indexed account, uint256 shares, uint256 amount);
-
-    /**
-     * @notice Emitted when redeemed underlying tokens are withdrawn
-     * @param account Withdrawing account
-     * @param amount Amount of underlying tokens withdrawn
-     */
-    event Withdrawn(address indexed account, uint256 amount);
-
-    /**
-     * @notice Emitted when USDC is deposited into a Bloom Pool
-     * @param tby TBY address
-     * @param amount Amount of TBY deposited
-     */
-    event TBYAutoMinted(address indexed tby, uint256 amount);
-
-    /**
-     * @notice Emitted when someone corrects the remaining balance
-     * using the poke function
-     * @param amount The updated remaining balance
-     */
-    event RemainingBalanceAdjusted(uint256 amount);
-
-    /**
-     * @notice Emitted when a fee is captured and sent to the Stakeup Staking
-     * @param feeType Fee type
-     * @param shares Number of stUSD shares sent to the Stakeup Staking
-     */
-    event FeeCaptured(FeeType feeType, uint256 shares);
 
     // =================== Functions ===================
     constructor(
@@ -144,7 +85,7 @@ contract StUSD is StUSDBase, ReentrancyGuard {
         address _bloomFactory,
         address _registry,
         uint16 _mintBps, // Suggested default 0.5%
-        uint16 _redeemBps, // Suggeste default 0.5%
+        uint16 _redeemBps, // Suggested default 0.5%
         uint16 _performanceBps, // Suggested default 10% of yield
         address _layerZeroEndpoint,
         address _wstUSD

--- a/src/token/StUSDBase.sol
+++ b/src/token/StUSDBase.sol
@@ -31,40 +31,6 @@ contract StUSDBase is IStUSD, OFTV2 {
     /// @dev Total amount of Usd
     uint256 internal _totalUsd;
 
-    // =================== Events ===================
-
-    /**
-     * @notice An executed shares transfer from `sender` to `recipient`.
-     * @dev emitted in pair with an ERC20-defined `Transfer` event.
-     * @param from Address of the sender
-     * @param to Address of the recipient
-     * @param sharesAmount Amount of shares transferred 
-     */
-    event TransferShares(address indexed from, address indexed to, uint256 sharesAmount);
-
-    /**
-     * @notice An executed `burnShares` request
-     * @dev Reports simultaneously burnt shares amount
-     * and corresponding stUSD amount.
-     * The stUSD amount is calculated twice: before and after the burning incurred rebase.
-     * @param account holder of the burnt shares
-     * @param preRebaseTokenAmount amount of stUSD the burnt shares corresponded to before the burn
-     * @param postRebaseTokenAmount amount of stUSD the burnt shares corresponded to after the burn
-     * @param sharesAmount amount of burnt shares
-    */
-    event SharesBurnt(
-        address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount
-    );
-
-    /**
-     * @notice Emitted when user deposits
-     * @param account User address
-     * @param token Address of the token being deposited
-     * @param amount Amount of tokens deposited
-     * @param shares Amount of shares minted to the user
-     */
-    event Deposit(address indexed account, address token, uint256 amount, uint256 shares);
-
     // =================== Functions ===================
 
     constructor(address _layerZeroEndpoint) 


### PR DESCRIPTION
This PR covers moving the remaining `events` & `errors` that are in `stUSD` & `stUSDBase`. The focus is to improve the readability of the contracts. 