### PR TITLE
BFI-1. VESTED TOKENS IN SUPVESTING CAN BE FULLY WITHDRAWN IMMEDIATELY AFTER CLIFF

### DIFF
--- a/src/token/SUPVesting.sol
+++ b/src/token/SUPVesting.sol
@@ -38,12 +38,13 @@ contract SUPVesting is ISUPVesting {
     function getAvailableTokens(address account) public view returns (uint256) {
         VestedAllocation memory allocation = _tokenAllocations[account];
         uint256 timeElapsed = _validateTimeElapsed(block.timestamp - allocation.vestingStartTime);
+        uint256 claimedTokens = allocation.startingBalance - allocation.currentBalance;
 
         if (timeElapsed < CLIFF_DURATION) {
             return 0;
         } else {
             return
-                allocation.startingBalance * timeElapsed / VESTING_DURATION;
+                allocation.startingBalance * timeElapsed / VESTING_DURATION - claimedTokens;
         }
     }
 


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
In the SUPVesting contract, vested tokens can be withdrawn using `claimAvailableTokens` . The function uses `getAvailableTokens` , which calculates the amount of available tokens.

However, `getAvailableTokens`  returns the amount without taking any
previous claims into account. It returns the whole amount that is vested
from the `startingBalance` . `claimAvailableTokens`  also only decreases
`currentBalance` , while `getAvailableTokens`  uses `startingBalance` .

As a result, the user can unlock all of their vested tokens after the cliff. At
this point, 1/3rd of the tokens have been vested, so they can all be unlocked
by calling claimAvailableTokens  3 times.

## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
This PR address BFI-1 from the Hexen's audit. `VESTED TOKENS IN SUPVESTING CAN BE FULLY WITHDRAWN IMMEDIATELY AFTER CLIFF`