### PR TITLE
BFI-2. CASTING OVERFLOW IN CLAIMING OF VESTED TOKENS IN SUPVESTING MAKES TOKENS UNCLAIMABLE

### DIFF
--- a/src/token/SUPVesting.sol
+++ b/src/token/SUPVesting.sol
@@ -68,7 +68,7 @@ contract SUPVesting is ISUPVesting {
     /// @inheritdoc ISUPVesting
     function claimAvailableTokens() external returns (uint256) {
         VestedAllocation storage allocation = _tokenAllocations[msg.sender];
-        uint256 amount = (getAvailableTokens(msg.sender));
+        uint256 amount = getAvailableTokens(msg.sender);
 
         allocation.currentBalance -= amount;
 


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
In the SUPVesting contract, vested tokens can be claimed using claimAvailableTokens.

The calculated amount is casted into uint32, even though the return value from getAvailableTokens is most likely going to be much larger than the maximum uint32. This will overflow and cut-off the higher bits of the amount, making it very small. This amount is then subtracted from currentBalance and sent to the user.

As a result, claiming of tokens will be limited to 4e9 tokens at a time (per function call / transaction). Given that the token has 18 decimals, this effectively locks the tokens in the contract and makes them unclaimable.

## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) --> 
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
This PR addresses issues presented in Hexen's audit - BFI-2