### PR TITLE
BFI-4. STAKEUPTOKEN VESTING GAS OPTIMISATION

### DIFF
--- a/src/token/StakeupToken.sol
+++ b/src/token/StakeupToken.sol
@@ -40,7 +40,7 @@ contract StakeupToken is IStakeupToken, OFT, Ownable2Step {
     function mintLpSupply(Allocation[] memory allocations) external onlyOwner {
         uint256 length = allocations.length;
         for (uint256 i = 0; i < length; i++) {
-            _mintAndVest(allocations[i], _vestingContract, MAX_SUPPLY);
+            _mintAndVest(allocations[i], _vestingContract);
         }
     }
 
@@ -77,7 +77,6 @@ contract StakeupToken is IStakeupToken, OFT, Ownable2Step {
         Allocation[] memory allocations,
         uint256 initialMintPercentage
     ) external override onlyOwner {
-        uint256 maxSupply = MAX_SUPPLY;
         uint256 sharesRemaining = initialMintPercentage;
         uint256 length = allocations.length;
 
@@ -86,18 +85,17 @@ contract StakeupToken is IStakeupToken, OFT, Ownable2Step {
                 revert ExceedsAvailableTokens();               
             }
             sharesRemaining -= allocations[i].percentOfSupply;
-            _mintAndVest(allocations[i], _vestingContract, maxSupply);
+            _mintAndVest(allocations[i], _vestingContract);
         }
         if (sharesRemaining > 0) revert SharesNotFullyAllocated();
     }
 
     function _mintAndVest(
         Allocation memory allocation,
-        address vestingContract,
-        uint256 maxTokenSupply
+        address vestingContract
     ) internal {
         TokenRecipient[] memory recipients = allocation.recipients;
-        uint256 tokensReserved = (maxTokenSupply * allocation.percentOfSupply) /
+        uint256 tokensReserved = (MAX_SUPPLY * allocation.percentOfSupply) /
             DECIMAL_SCALING;
         uint256 allocationRemaining = tokensReserved;
         uint256 length = recipients.length;


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
The function `_mintAndVest`  always uses the value of the constant `MAX_SUPPLY`  for it’s input `maxTokenSupply` . Therefore, there is no need for this input to exist, every instance of `maxTokenSupply`  can be replaced by
`MAX_SUPPLY`  and the input variable can be removed. This will also remove another gas inefficiency in `mintInitialSupply`  in line 80 where `MAX_SUPPLY`  is unnecessarily cached to the stack.

## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
This PR addresses BFI-4 from the Hexen's audit.