### PR TITLE
BFI-13. UNUSED TIMESTAMP VARIABLE IN WITHDRAWALREQUEST STRUCT

### DIFF
--- a/src/interfaces/IRedemptionNFT.sol
+++ b/src/interfaces/IRedemptionNFT.sol
@@ -22,7 +22,6 @@ interface IRedemptionNFT {
     struct WithdrawalRequest {
         uint256 amountOfShares;
         address owner;
-        uint40 timestamp;
         bool claimed;
     }
 

--- a/src/token/RedemptionNFT.sol
+++ b/src/token/RedemptionNFT.sol
@@ -35,7 +35,6 @@ contract RedemptionNFT is IRedemptionNFT, ONFT721 {
         _withdrawalRequests[tokenId] = WithdrawalRequest({
             amountOfShares: shares,
             owner: to,
-            timestamp: uint40(block.timestamp),
             claimed: false
         });
 


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
In the `RedemptionNFT` smart contract, specifically within the `addWithdrawalRequest` function, a `WithdrawalRequest` struct is created and assigned values. This struct includes a timestamp field which is set using `uint40(block.timestamp)`. However, this `timestamp` field is not utilized anywhere else in the contract.

## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
This PR addresses BFI-13 from the Hexen's audit. 