### PR TITLE
BFI-18. PRECISION LOSS LEADING TO EXCESSIVE REWARD DISTRIBUTION

### DIFF
--- a/src/rewards/RewardBase.sol
+++ b/src/rewards/RewardBase.sol
@@ -57,7 +57,7 @@ abstract contract RewardBase {
         }
 
         // Calculate total tokens unlocked using the formula for the sum of a geometric series
-        uint256 tokensUnlocked = rewardSupply * (DECIMAL_SCALING - (DECIMAL_SCALING / 2**year));
+        uint256 tokensUnlocked = rewardSupply * (DECIMAL_SCALING - (DECIMAL_SCALING / 2**year)) / DECIMAL_SCALING;
         uint256 yearlyAllocation = tokensUnlocked - rewardsPaid;
 
         return timeElapsed * yearlyAllocation / 365 days;

--- a/test/RewardManager.t.sol
+++ b/test/RewardManager.t.sol
@@ -21,6 +21,7 @@ contract RewardManagerTest is Test {
     MockCurveFactory public mockCurveFactory;
     StakeupStaking public stakeupStaking;
 
+    uint256 internal constant DECIMAL_SCALING = 1e18;
     uint256 constant MAX_POKE_REWARDS = 1_000_000_000e18 * 1e16 / 1e18;
     uint256 constant MAX_POOL_REWARDS = 1_000_000_000e18 * 2e17 / 1e18;
     uint256 constant MAX_MINT_REWARDS = 1_000_000_000e18 * 1e17 / 1e18;
@@ -103,7 +104,7 @@ contract RewardManagerTest is Test {
 
         skip(3 days);
         uint256 year = 1;
-        uint256 yearOneRewards = MAX_POKE_REWARDS * (1 - (1 / 2**year));
+        uint256 yearOneRewards = MAX_POKE_REWARDS * (DECIMAL_SCALING - (DECIMAL_SCALING / 2**year)) / DECIMAL_SCALING;
 
         uint256 expectedReward = 3 days * yearOneRewards / 365 days;
         
@@ -132,7 +133,7 @@ contract RewardManagerTest is Test {
         for (uint256 i = 0; i < data.length; i++) {
             uint256 week = 1 weeks;
             uint256 year = 1;
-            uint256 yearOneRewards = data[i].maxRewards * (1 - (1 / 2**year));
+            uint256 yearOneRewards = data[i].maxRewards * (DECIMAL_SCALING - (DECIMAL_SCALING / 2**year)) / DECIMAL_SCALING;
 
             uint256 expectedReward = week * yearOneRewards / 365 days;
 


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
The `_calculateDripAmount` function (lines 38-64) within the `RewardBase` contract has a precision issue on line 60: `uint256 tokensUnlocked = rewardSupply * (1 - (1 / 2**year))`, which affects the accurate calculation of rewards. This results in overestimating the total unlocked tokens for distribution, leading to a larger distribution than intended, as the `(1 / 2**year)` part will always return `0` so the `tokensUnlocked` will be equal to `rewardSupply`. Consequently, the function returns a larger-than-intended value for the rewards, which impacts functions that utilize this calculation.
The `distributePokeRewards` function (lines 49-67) in the `RewardManager.sol` contract, is using function `_calculateDripAmount`.

## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
This PR addresses BFI-18 from the Hexen's audit. 