### PR TITLE
BFI-9. STUSDBASE SHOULD OVERRIDE OFT DEBIT AND CREDIT FUNCTIONS

### DIFF
--- a/src/token/StUSDBase.sol
+++ b/src/token/StUSDBase.sol
@@ -396,4 +396,26 @@ abstract contract StUSDBase is IStUSD, OFT {
         emit Transfer(from, to, tokenAmount);
         emit TransferShares(from, to, sharesAmount);
     }
+
+    function _debitFrom(
+        address _from,
+        uint16,
+        bytes memory,
+        uint _amount
+    ) internal override returns (uint) {
+        address spender = _msgSender();
+        if (_from != spender) _spendAllowance(_from, spender, _amount);
+        uint256 shares = getSharesByUsd(_amount);
+        _burnShares(_from, shares);
+        return _amount;
+    }
+
+    function _creditTo(
+        uint16,
+        address _toAddress,
+        uint _amount
+    ) internal override returns (uint) {
+        _mintShares(_toAddress, getSharesByUsd(_amount));
+        return _amount;
+    }
 }


### PR DESCRIPTION
# Description

**Issue:**

The StUSDBase contract implements `_mintShares()` and `_burnShares()` to mint/burn `stUSD`. In these functions it increases and decreases the `_shares` mapping for the user, which is the balance of the user.
Whereas `OFT` inherits from `ERC20` and uses `_mint()`and `_burn` inside `_debitFrom()` and `_creditTo()`. These 2 functions are called upon sending and receiving of tokens through LayerZero.
Both `_mint` and `_burn` use the _balances mapping from ERC20 to increase/decrease balance. Because the user would never have any balance in there (but in shares instead), it would mean that unless `StUSDBase` overrides those functions of `OFT` and use correct mint/burn functions, it's impossible to transfer `stUSD` through LayerZero.

**Remediation**: 

This PR overrides `_debitFrom` and `_creditTo` in the `StUSDBase` contract to allow for proper accounting when sending and receiving tokens via LayerZero.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->