### PR TITLE
BFI-8. MISSING TRUSTED REMOTE SETTER LEADS TO REDEMPTIONNFT NOT BEING ABLE TO BE BRIDGED

### DIFF
--- a/src/interfaces/IStUSD.sol
+++ b/src/interfaces/IStUSD.sol
@@ -189,6 +189,13 @@ interface IStUSD {
      */
     function withdraw(address account, uint256 shares) external;
 
+    /**
+     * 
+     * @param remoteChainId The chainId of the remote chain
+     * @param path abi.encodePacked(remoteAddress, localAddress)
+     */
+    function setNftTrustedRemote(uint16 remoteChainId, bytes calldata path) external;
+
     /// @notice Returns the WstUSD contract
     function getWstUSD() external view returns (IWstUSD);
 

--- a/src/token/StUSD.sol
+++ b/src/token/StUSD.sol
@@ -262,6 +262,11 @@ contract StUSD is StUSDBase, ReentrancyGuard {
     }
 
     /// @inheritdoc IStUSD
+    function setNftTrustedRemote(uint16 remoteChainId, bytes calldata path) external onlyOwner {
+        _redemptionNFT.setTrustedRemote(remoteChainId, path);
+    }
+    
+    /// @inheritdoc IStUSD
     function getWstUSD() external view returns (IWstUSD) {
         return _wstUSD;
     }


### PR DESCRIPTION
# Description

**Issue**:

The `RedemptionNFT` inherits from `ONFT721` which is used to bridge the token between multiple networks using LayerZero. As per the documentation of the LayerZero, the contract must set a trusted remote from which he will trust the messages (note: this is not the same as `lzEndpoint`, this is used to check the source address of the source chain from which the message came).
While usually it’s possible for the owner of the contract to set the trusted remote after deploying the token because the `setTrustedRemote()` function is public, in case of the `RedemptionNFT` it’s deployed in the constructor of the `StUSD.sol:L119-124` which makes the `StUSD` the owner of the `RedemptionNFT` contract.
Because `StUSD.sol` is missing the setter for the trusted remote of the `RedemptionNFT` and because the owner is the `StUSD` contract, it’s impossible to change the trusted remote of the `RedemptionNFT`.

This makes it so it’s impossible to bridge the NFT between chains because the `lzReceive()` function inside of the `LzApp.sol` (which the `ONFT721` inherits down the line) has a require which checks if the source message came from a trusted remote which in this case will always be empty thus making the bridging of the token impossible.

**Remediation**:

This PR fixes this issue by adding a protected setter function that can be called by the owner of `StUSD`, `setNftTrustedRemote`, that sets the trusted remote for various destination chains.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->