### PR TITLE
BFI-15. RISK OF EXCEEDING TOKEN MAX_SUPPLY ALLOCATION

### DIFF
--- a/src/interfaces/IStakeupToken.sol
+++ b/src/interfaces/IStakeupToken.sol
@@ -7,6 +7,9 @@ interface IStakeupToken {
     /// @notice Amount being minted is greater than the available tokens
     error ExceedsAvailableTokens();
 
+    ///@notice Amount being minted is greater than the allocation limit
+    error ExceedsMaxAllocationLimit();
+
     /// @notice Amount being minted is greater than the supply cap
     error ExceedsMaxSupply();
 

--- a/src/token/StakeupToken.sol
+++ b/src/token/StakeupToken.sol
@@ -88,6 +88,8 @@ contract StakeupToken is IStakeupToken, OFT, Ownable2Step {
             sharesRemaining -= allocations[i].percentOfSupply;
             _mintAndVest(allocations[i], _vestingContract, maxSupply);
         }
+        if (totalSupply() > MAX_SUPPLY) revert ExceedsMaxAllocationLimit();
+
         if (sharesRemaining > 0) revert SharesNotFullyAllocated();
     }
 


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->
The `mintInitialSupply`  function (lines 76-92) in the `StakeupToken`  contract allows the initial allocation of tokens to multiple recipients based on the provided percentages. Presently, the function lacks a validation check on the `initialMintPercentage`  parameter, potentially allowing for an allocation that exceeds the total token supply of 100%. `initialMintPercentage` : This represents the intended percentage of the total token supply that will be allocated during the initial minting process. It defines the fraction of tokens to be distributed across various allocations.

## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
This PR addresses BFI-15 from the Hexen's audit. 