### PR TITLE
BFI-10. REDEMPTIONNFT CROSS-CHAIN TRANSFERS CAN CAUSE THEFT AND LOSS OF FUNDS

### DIFF
--- a/src/token/RedemptionNFT.sol
+++ b/src/token/RedemptionNFT.sol
@@ -31,7 +31,6 @@ contract RedemptionNFT is IRedemptionNFT, ONFT721 {
     ) external override onlyStUSD returns (uint256) {
         uint256 tokenId = _generateNextTokenId();
 
-        
         _withdrawalRequests[tokenId] = WithdrawalRequest({
             amountOfShares: shares,
             owner: to,

--- a/test/StUSD.t.sol
+++ b/test/StUSD.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.19;
 
 import {Test} from "forge-std/Test.sol";
 import {LibRLP} from "solady/utils/LibRLP.sol";
-import {console2} from "forge-std/console2.sol";
 
 import {StUSD} from "src/token/StUSD.sol";
 import {WstUSD} from "src/token/WstUSD.sol";


### PR DESCRIPTION
# Description

**Issue:**
The RedemptionNFT implements LayerZero’s `ONFT `to facilitate cross-chain transfers. However, the IDs of these NFTs and their linked withdrawal requests won’t be in sync across different chains.
For example, if one creates a withdrawal request with ID 1, they will also get minted the NFT with ID 1. The `RedemptionNFT` keeps a local counter `_mintCount` to keep track of IDs.

However, if this `RedemptionNFT` now gets transferred to another chain, then it will break the logic of IDs on the other. If the ID 1 does not exist yet on the other chain, then the user will get minted another `RedemptionNFT` on the other chain with ID 1. As can be seen in `ONFT721.sol:_creditTo`.

In the other case, if someone else had already created a withdrawal request and `RedemptionNFT` with the same ID, then it would try to call `_transfer` on the token ID.
There are again 2 cases, if the NFT on the other chain was still in possession of the other user, then this transaction would fail, because address(this) is not the owner of the NFT. This would result in the `RedemptionNFT` to get stuck.
The other case is where the other user also had transferred their `RedemptionNFT` to another chain. The NFT would’ve been transferred to the `RedemptionNFT` contract as an escrow and in that case the `_transfer` would work, as address(this) is indeed the owner.
Due to the override of `_transfer` in `RedemptionNFT.sol`, the owner of the withdrawal request would also be set to the owner of the NFT.

**Remediation:**
This PR is a complete overhaul of the cross-chain bridging of `RedemptionNFT`s. It resolves the vulnerability above by allowing users to redeem and bridge their NFT on any chain. This is done through the creation of unique `tokenId`s that combine chainId and the local `_mintCount` variable with a buffer in between.  In order to achieve this, `_send`, `_nonblockingLzReceive` and `clearCredits` have been overriden to allow for bridging `_withdrawRequestData` between chains. 

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->