### PR TITLE
BFI-12. REDEMPTIONNFT CROSS-CHAIN TRANSFERS WILL FAIL DUE TO WRONG GAS VALUE

### DIFF
--- a/src/token/RedemptionNFT.sol
+++ b/src/token/RedemptionNFT.sol
@@ -20,7 +20,7 @@ contract RedemptionNFT is IRedemptionNFT, ONFT721 {
         string memory symbol,
         address stUSD,
         address lzEndpoint
-    ) ONFT721(name, symbol, 1, lzEndpoint) {
+    ) ONFT721(name, symbol, 500000, lzEndpoint) {
         _stUSD = stUSD;
     }
 


### PR DESCRIPTION
# Description

**Issue:**
In the constructor of `RedemptionNFT`, the `_minGasToTransfer` parameter for the inherited `ONFT721` contract is set to 1, which is significantly below the required gas amount for a typical `ERC721` NFT transfer. This setting will cause cross-chain NFT transfer transactions to fail due to insufficient gas. ERC721 transfers generally require at least 100,000 gas, depending on the complexity of the contract.

**Remediation:**
This PR updates minimum gas available to transfer to be 500,000 from 1. This ensures that there is enough gas available to successfully transfer the NFT cross-chain.

## Type of change

- [x] Audit fix <!-- (non-breaking change which fixes an issue) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
