### PR TITLE
BFI-7. STUSD AND TBY MAY HAVE DIFFERENT UNDERLYING TOKENS

### DIFF
--- a/src/interfaces/IStUSD.sol
+++ b/src/interfaces/IStUSD.sol
@@ -26,7 +26,10 @@ interface IStUSD {
 
     /// @notice Invalid amount
     error InvalidAmount();
-
+    
+    /// @notice Invalid Underlying Token
+    error InvalidUnderlyingToken();
+    
     /// @notice TBY not active
     error TBYNotActive();
 

--- a/src/interfaces/bloom/IBloomPool.sol
+++ b/src/interfaces/bloom/IBloomPool.sol
@@ -25,4 +25,6 @@ interface IBloomPool is IERC20 {
     function COMMIT_PHASE_END() external view returns (uint256);
 
     function EMERGENCY_HANDLER() external view returns (address);
+
+    function UNDERLYING_TOKEN() external view returns (address);
 }

--- a/src/token/StUSD.sol
+++ b/src/token/StUSD.sol
@@ -128,6 +128,7 @@ contract StUSD is StUSDBase, ReentrancyGuard {
     function depositTby(address tby, uint256 amount) external nonReentrant {
         if (!_registry.tokenInfos(tby).active) revert TBYNotActive();
         IBloomPool latestPool = _getLatestPool();
+        if (latestPool.UNDERLYING_TOKEN() != address(_underlyingToken)) revert InvalidUnderlyingToken();
 
         IERC20(tby).safeTransferFrom(msg.sender, address(this), amount);
 

--- a/test/mock/MockBloomPool.sol
+++ b/test/mock/MockBloomPool.sol
@@ -105,4 +105,8 @@ contract MockBloomPool is IBloomPool, MockERC20 {
     function emergencyBurn(uint256 amount) external {
         _burn(msg.sender, amount);
     }
+
+    function UNDERLYING_TOKEN() external view override returns (address) {
+        return address(underlyingToken);
+    }
 }


### PR DESCRIPTION
# Description

**Issue:**
It's implicitly assumed that `stUSD` has the same underlying token as `TBY`. However, it's never enforced in the code.
Inside the `depositTby()` function, the only condition checked is that `TBY` is registered and active. So, it's possible to present any `TBY` token available.

**Remediation:**
Checks within the `depositTBY` function enforce that the underlying token is the same for `stUSD` and the `TBY` being deposited. 

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
