### PR TITLE
BFI-20. MALICIOUS USER CAN BLOCK STUSD DEPOSITS BY TRANSFERRING STUSD FROM ANOTHER CHAIN

### DIFF
--- a/src/token/StUSDBase.sol
+++ b/src/token/StUSDBase.sol
@@ -187,10 +187,17 @@ abstract contract StUSDBase is IStUSD, OFT {
     /// @inheritdoc IStUSD
     function getSharesByUsd(uint256 usdAmount) public view override returns (uint256) {
         uint256 totalShares = _getTotalShares();
+        uint256 totalUsd = _getTotalUsd();
+        
         if (totalShares == 0) {
             return usdAmount;
         }
-        return (usdAmount * totalShares) / _getTotalUsd();
+
+        if (totalUsd == 0) {
+            return totalShares;
+        }
+
+        return (usdAmount * totalShares) / totalUsd;
     }
     
     /// @inheritdoc IStUSD


### PR DESCRIPTION
# Description

**Issue:**
A vulnerability exists in the `getSharesByUsd` function of the `StUSDBase` contract. The function is intended to calculate the number of shares a user would receive for a given USD amount. It checks if `totalShares` is zero; if so, it returns the `usdAmount`.
An issue arises when a user transfers `StUSD` tokens from another chain into the contract, when the `StUSD` contract on the receiving has just been created. The issue lies in the division operation `(usdAmount * totalShares) / _getTotalUsd()`.
If some shares were transferred in, then `totalSupply` will be greater than 0, but `totalUsd` would still be 0. `_getTotalUsd()` returns zero (which can happen when a malicious user front-runs and transfers tokens from another chain), it leads to a division-by-zero error, causing the transaction to revert.

**Remediation:**
This PR adds a check if `_getTotalUsd` is zero and returns the `totalShares` value for `getSharesByUsd` in order to mitigate the edge case where `_getTotalUsd` reverts due to division by 0.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
