### PR TITLE
Removed unnecessary arguments for Withdraw requests

### DIFF
--- a/src/token/RedemptionNFT.sol
+++ b/src/token/RedemptionNFT.sol
@@ -228,7 +228,6 @@ contract RedemptionNFT is IRedemptionNFT, ONFT721 {
             _withdrawalRequests[tokenIds[i]] = WithdrawalRequest({
                 amountOfShares: amountOfShares[i],
                 owner: toAddress,
-                timestamp: uint40(block.timestamp),
                 claimed: false
             });
 

--- a/test/StakeupStaking.t.sol
+++ b/test/StakeupStaking.t.sol
@@ -183,7 +183,6 @@ contract StakeupStakingTest is Test {
             uint256 rewardRate = rewardData.rewardRate;
             uint96 rewardPerTokenStaked = rewardData.rewardPerTokenStaked;
             uint256 availableRewards = rewardData.availableRewards;
-            uint256 pendingRewards = rewardData.pendingRewards;
 
             assertEq(availableRewards, rewardSupply);
             assertEq(rewardRate, rewardSupply.divWad(1 weeks));


### PR DESCRIPTION
# Description

Removes the unnecessary argument `timestamp` from `WithdrawRequest` in `RedemptionNFT`. This issue was caused by merge conflicts.

## Type of change

- [ ] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
