### PR TITLE
Make `StUSDBase` a Deployable Contract

### DIFF
--- a/src/interfaces/IStUSD.sol
+++ b/src/interfaces/IStUSD.sol
@@ -7,9 +7,11 @@ import {IBloomFactory} from "./bloom/IBloomFactory.sol";
 import {IExchangeRateRegistry} from "./bloom/IExchangeRateRegistry.sol";
 import {IStakeupStaking} from "./IStakeupStaking.sol";
 import {IRewardManager} from "./IRewardManager.sol";
+import {IStUSDBase} from "./IStUSDBase.sol";
+
 import {RedemptionNFT} from "src/token/RedemptionNFT.sol";
 
-interface IStUSD {
+interface IStUSD is IStUSDBase {
     // =================== Errors ===================
 
     /// @notice Caller is not the Redemption NFT
@@ -89,29 +91,6 @@ interface IStUSD {
     event FeeCaptured(FeeType feeType, uint256 shares);
 
     /**
-     * @notice An executed shares transfer from `sender` to `recipient`.
-     * @dev emitted in pair with an ERC20-defined `Transfer` event.
-     * @param from Address of the sender
-     * @param to Address of the recipient
-     * @param sharesAmount Amount of shares transferred 
-     */
-    event TransferShares(address indexed from, address indexed to, uint256 sharesAmount);
-
-    /**
-     * @notice An executed `burnShares` request
-     * @dev Reports simultaneously burnt shares amount
-     * and corresponding stUSD amount.
-     * The stUSD amount is calculated twice: before and after the burning incurred rebase.
-     * @param account holder of the burnt shares
-     * @param preRebaseTokenAmount amount of stUSD the burnt shares corresponded to before the burn
-     * @param postRebaseTokenAmount amount of stUSD the burnt shares corresponded to after the burn
-     * @param sharesAmount amount of burnt shares
-    */
-    event SharesBurnt(
-        address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount
-    );
-
-    /**
      * @notice Emitted when user deposits
      * @param account User address
      * @param token Address of the token being deposited
@@ -120,36 +99,6 @@ interface IStUSD {
      */
     event Deposit(address indexed account, address token, uint256 amount, uint256 shares);
     
-    /**
-     * @return the entire amount of Usd controlled by the protocol.
-     * @dev The sum of all USD balances in the protocol, equals to the total supply of stUSD.
-     */
-    function getTotalUsd() external view returns (uint256);
-    /**
-     * @notice Get the total amount of shares in existence.
-     * @dev The sum of all accounts' shares can be an arbitrary number, therefore
-     * it is necessary to store it in order to calculate each account's relative share.
-     */
-    function getTotalShares() external view returns (uint256);
-        /**
-     * @notice Get the amount of shares owned by `_account`
-     * @param account Account to get shares of
-     */
-    function sharesOf(address account) external view returns (uint256);
-
-    /**
-     * @notice Get the amount of shares that corresponds to a given dollar value.
-     * @param usdAmount Amount of Usd
-     */
-    function getSharesByUsd(uint256 usdAmount) external view returns (uint256);
-
-    /**
-     * @notice Get the amount of Usd that corresponds to a given number of token shares.
-     * @param sharesAmount Amount of shares
-     * @return Amount of Usd that corresponds to `sharesAmount` token shares.
-     */
-    function getUsdByShares(uint256 sharesAmount) external view returns (uint256);
-
     /**
      * @notice Deposit TBY and get stUSD minted
      * @param tby TBY address

--- a/src/interfaces/IStUSDBase.sol
+++ b/src/interfaces/IStUSDBase.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+interface IStUSDBase {
+    /**
+     * @notice An executed shares transfer from `sender` to `recipient`.
+     * @dev emitted in pair with an ERC20-defined `Transfer` event.
+     * @param from Address of the sender
+     * @param to Address of the recipient
+     * @param sharesAmount Amount of shares transferred 
+     */
+    event TransferShares(address indexed from, address indexed to, uint256 sharesAmount);
+    
+    /**
+     * @notice An executed `burnShares` request
+     * @dev Reports simultaneously burnt shares amount
+     * and corresponding stUSD amount.
+     * The stUSD amount is calculated twice: before and after the burning incurred rebase.
+     * @param account holder of the burnt shares
+     * @param preRebaseTokenAmount amount of stUSD the burnt shares corresponded to before the burn
+     * @param postRebaseTokenAmount amount of stUSD the burnt shares corresponded to after the burn
+     * @param sharesAmount amount of burnt shares
+    */
+    event SharesBurnt(
+        address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount
+    );
+
+    /**
+     * @return the entire amount of Usd controlled by the protocol.
+     * @dev The sum of all USD balances in the protocol, equals to the total supply of stUSD.
+     */
+    function getTotalUsd() external view returns (uint256);
+    /**
+     * @notice Get the total amount of shares in existence.
+     * @dev The sum of all accounts' shares can be an arbitrary number, therefore
+     * it is necessary to store it in order to calculate each account's relative share.
+     */
+    function getTotalShares() external view returns (uint256);
+        /**
+     * @notice Get the amount of shares owned by `_account`
+     * @param account Account to get shares of
+     */
+    function sharesOf(address account) external view returns (uint256);
+
+    /**
+     * @notice Get the amount of shares that corresponds to a given dollar value.
+     * @param usdAmount Amount of Usd
+     */
+    function getSharesByUsd(uint256 usdAmount) external view returns (uint256);
+
+    /**
+     * @notice Get the amount of Usd that corresponds to a given number of token shares.
+     * @param sharesAmount Amount of shares
+     * @return Amount of Usd that corresponds to `sharesAmount` token shares.
+     */
+    function getUsdByShares(uint256 sharesAmount) external view returns (uint256);
+
+}

--- a/src/token/StUSD.sol
+++ b/src/token/StUSD.sol
@@ -7,7 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import {RedemptionNFT} from "./RedemptionNFT.sol";
-import {StUSDBase, IStUSD} from "./StUSDBase.sol";
+import {StUSDBase} from "./StUSDBase.sol";
 
 import {IBloomFactory} from "../interfaces/bloom/IBloomFactory.sol";
 import {IBloomPool} from "../interfaces/bloom/IBloomPool.sol";
@@ -15,10 +15,11 @@ import {IEmergencyHandler} from "../interfaces/bloom/IEmergencyHandler.sol";
 import {IExchangeRateRegistry} from "../interfaces/bloom/IExchangeRateRegistry.sol";
 import {IRewardManager} from "../interfaces/IRewardManager.sol";
 import {IStakeupStaking} from "../interfaces/IStakeupStaking.sol";
+import {IStUSD} from "../interfaces/IStUSD.sol";
 import {IWstUSD} from "../interfaces/IWstUSD.sol";
 
 /// @title Staked USD Contract
-contract StUSD is StUSDBase, ReentrancyGuard {
+contract StUSD is IStUSD, StUSDBase, ReentrancyGuard {
     using Math for uint256;
     using SafeERC20 for IERC20;
     using SafeERC20 for IWstUSD;

--- a/src/token/StUSDBase.sol
+++ b/src/token/StUSDBase.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.22;
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
 import {OFT, IERC20, ERC20} from "@layerzerolabs/token/oft/v1/OFT.sol";
-import {IStUSD} from "../interfaces/IStUSD.sol";
+import {IStUSDBase} from "../interfaces/IStUSDBase.sol";
 
 /// @title Staked USD Base Contract
-abstract contract StUSDBase is IStUSD, OFT {
+contract StUSDBase is IStUSDBase, OFT {
     using FixedPointMathLib for uint256;
     // =================== Constants ===================
 
@@ -56,8 +56,8 @@ abstract contract StUSDBase is IStUSD, OFT {
         return _getTotalUsd();
     }
 
-    /// @inheritdoc IStUSD
-    function getTotalUsd() external view returns (uint256) {
+    /// @inheritdoc IStUSDBase
+    function getTotalUsd() external view override returns (uint256) {
         return _getTotalUsd();
     }
 
@@ -177,17 +177,17 @@ abstract contract StUSDBase is IStUSD, OFT {
         return true;
     }
 
-    /// @inheritdoc IStUSD
-    function getTotalShares() external view returns (uint256) {
+    /// @inheritdoc IStUSDBase
+    function getTotalShares() external view override returns (uint256) {
         return _getTotalShares();
     }
 
-    /// @inheritdoc IStUSD
-    function sharesOf(address account) external view returns (uint256) {
+    /// @inheritdoc IStUSDBase
+    function sharesOf(address account) external view override returns (uint256) {
         return _sharesOf(account);
     }
 
-    /// @inheritdoc IStUSD
+    /// @inheritdoc IStUSDBase
     function getSharesByUsd(uint256 usdAmount) public view override returns (uint256) {
         uint256 totalShares = _getTotalShares();
         uint256 totalUsd = _getTotalUsd();
@@ -202,7 +202,7 @@ abstract contract StUSDBase is IStUSD, OFT {
         return usdAmount.mulWad(totalShares).divWad(_getTotalUsd());
     }
     
-    /// @inheritdoc IStUSD
+    /// @inheritdoc IStUSDBase
     function getUsdByShares(uint256 sharesAmount) public view override returns (uint256) {
         uint256 totalShares = _getTotalShares();
         if (totalShares == 0) {


### PR DESCRIPTION
# Description

Currently `StUSD` is an abstract contract, but this creates some issues when we have `StUSD` deployed on blockchains that do not have `BloomPool` on them. In the event this happens there will be a large amount of unnecessary code that will revert everytime a user calls the contract. Due to the fact that `BloomPool`s will only be deployed on a few select chains and that `StUSD` should be omnichain and able to be seamlessly integrated anywhere, this is a sub-optimal solution. This PR addresses this issue by reorganizing the interface for `StUSD` and adding all functions and events from `StUSDBase` into a new interface `IStUSDBase` this interface is then inherited into `IStUSD`. The `StUSDBase` contract is also a regular contract not abstract anymore, as it will be deployed as the main token contract on all blockchains that do not use `BloomPool`s.

Not only does this feature improve the user experience of `StUSD` but also cuts deployment costs and bytecode size by almost half for `StUSD` deployments on chains that do not support `BloomPool`s.

**Deployment Size of stUSD on Unsupported Chains:**
| stUSD Instance Pre-Fix | stUSD Instance Post-Fix|
|:---------------------------|:----------------------------|
| 23.959 kB | 14.506 kB |
## Type of change

- [ ] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
