### PR TITLE
M-01 stUSD deposit fees are sent but never processed causing loss of yield for stakers

### DIFF
--- a/src/token/StUSD.sol
+++ b/src/token/StUSD.sol
@@ -341,6 +341,7 @@ contract StUSD is IStUSD, StUSDBase, ReentrancyGuard {
 
         _mintShares(msg.sender, sharesAmount);
         _mintShares(address(_stakeupStaking), sharesFeeAmount);
+        _stakeupStaking.processFees(sharesFeeAmount);
 
         uint256 totalUsd = _getTotalUsd();
 

--- a/tests/mocks/MockStakeupStaking.sol
+++ b/tests/mocks/MockStakeupStaking.sol
@@ -8,8 +8,11 @@ import {ISUPVesting} from "src/interfaces/ISUPVesting.sol";
 
 contract MockStakeupStaking is IStakeupStaking {
     address private _rewardManager;
+    bool private _feeProcessed;
 
-    function processFees(uint256 amount) external override {}
+    function processFees(uint256 amount) external override {
+        _feeProcessed = true;
+    }
 
     function stake(uint256 stakeupAmount) external override {}
 
@@ -62,4 +65,14 @@ contract MockStakeupStaking is IStakeupStaking {
     function getUserStakingData(
         address user
     ) external view override returns (StakingData memory) {}
+
+    // This function is only used for unit testing
+    function setFeeProcessed(bool feeProcessed) external {
+        _feeProcessed = feeProcessed;
+    }
+    
+    // This function is only used for unit testing
+    function isFeeProcessed() external view returns (bool) {
+        return _feeProcessed;
+    }
 }

--- a/tests/wake_testing/test_st_usd.py
+++ b/tests/wake_testing/test_st_usd.py
@@ -251,6 +251,21 @@ def test_auto_minting():
     # user balance should increase after redeeming but not after auto minting
     # assert st_usd.balanceOf(user.address) == user_bal_after
 
-# TODO: Add tests during audit fix
-def test_balance_adjustments():
-    pass
+@default_chain.connect()
+def test_deposit_fee():
+    deploy_env(default_chain)
+    stakeup.setFeeProcessed(False)
+
+    user = default_chain.accounts[1]
+
+    deposit_amount = 1000
+    deposit_fee = st_usd.getMintBps() * deposit_amount / 10000
+
+    registry.setExchangeRate(bloom_pool.address, EvmMath.parse_eth(1))
+    deposit(default_chain, user, EvmMath.parse_decimals(deposit_amount, 6), False)
+
+    assert st_usd.balanceOf(stakeup.address) == EvmMath.parse_eth(deposit_fee)
+    assert stakeup.isFeeProcessed() == True
+
+
+


### PR DESCRIPTION
# Description

This PR addresses issue M-01 where deposit fees are not processed thus causing a loss of yield for stakers in Stakeup. The fix for this issue is pretty straight forward in adding a `processFees` call after sending mint fees to `_stakeupStaking`.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
