### PR TITLE
INT-03 Clean up underlying token checks

### DIFF
--- a/src/token/StUSD.sol
+++ b/src/token/StUSD.sol
@@ -128,8 +128,12 @@ contract StUSD is IStUSD, StUSDBase, ReentrancyGuard {
     /// @inheritdoc IStUSD
     function depositTby(address tby, uint256 amount) external nonReentrant {
         if (!_registry.tokenInfos(tby).active) revert TBYNotActive();
+        
+        if (IBloomPool(tby).UNDERLYING_TOKEN() != address(_underlyingToken)) {
+            revert InvalidUnderlyingToken();
+        }
+
         IBloomPool latestPool = _getLatestPool();
-        if (latestPool.UNDERLYING_TOKEN() != address(_underlyingToken)) revert InvalidUnderlyingToken();
 
         IERC20(tby).safeTransferFrom(msg.sender, address(this), amount);
 
@@ -144,6 +148,10 @@ contract StUSD is IStUSD, StUSDBase, ReentrancyGuard {
     function depositUnderlying(uint256 amount) external nonReentrant {
         _underlyingToken.safeTransferFrom(msg.sender, address(this), amount);
         IBloomPool latestPool = _getLatestPool();
+
+        if (latestPool.UNDERLYING_TOKEN() != address(_underlyingToken)) {
+            revert InvalidUnderlyingToken();
+        }
 
         if (latestPool.state() == IBloomPool.State.Commit) {
             _lastDepositAmount += amount;


### PR DESCRIPTION
# Description

This PR cleans up the underlying token checks within `depositTBY` and `depositUnderlying`. Besides changing the check from an inline if statement to an if statement with brackets we also added a check to `depositUnderlying` and switched the check in `depostTBY` from verifying the `latestPool`'s `UNDERLYING_TOKEN` to the `tby` that is being deposited.

## Type of change

- [ ] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
