### PR TITLE
OS-BFI-SUG-01: Redundant Function Call

### DIFF
--- a/src/token/StTBYBase.sol
+++ b/src/token/StTBYBase.sol
@@ -266,7 +266,7 @@ contract StTBYBase is IStTBYBase, OFT {
             return totalShares;
         }
 
-        return usdAmount.mulWad(totalShares).divWad(_getTotalUsd());
+        return usdAmount.mulWad(totalShares).divWad(totalUsd);
     }
 
     /// @inheritdoc IStTBYBase


### PR DESCRIPTION
# Description

In `StTBYBase#getSharedByUsd` `totalUsd` is stored in memory at the start of the function. Over the course of the function call there is no changes to this variable, but when calculating the final return value, `_getTotalUsd` is called again. This extra call is unneeded and wastes gas. This second call is removed and instead replaced by the existing local variable `totalUsd`.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
