### PR TITLE
OS-BFI-ADV-02: Inconsistency In Batch Messaging Implementation

### DIFF
--- a/src/messaging/StakeUpMessenger.sol
+++ b/src/messaging/StakeUpMessenger.sol
@@ -15,7 +15,6 @@ import {IStakeUpMessenger} from "../interfaces/IStakeUpMessenger.sol";
  *         between cross-chain instances.
  */
 contract StakeUpMessenger is IStakeUpMessenger, OApp {
-
     // =================== Storage ===================
 
     /// @dev Address of stTBY contract
@@ -189,11 +188,16 @@ contract StakeUpMessenger is IStakeUpMessenger, OApp {
                 message,
                 options,
                 MessagingFee(providedFee, 0),
-                payable(refundRecipient)
+                address(this)
             );
 
             providedFee -= receipt.fee.nativeFee;
             receipts[i] = receipt;
+        }
+
+        // If there is excess fee, refund it to the refundRecipient
+        if (providedFee > 0) {
+            payable(refundRecipient).transfer(providedFee);
         }
     }
 
@@ -262,6 +266,23 @@ contract StakeUpMessenger is IStakeUpMessenger, OApp {
     }
 
     /**
+     * @notice Pays the native fee associated with the message
+     * @dev Overrides the OAppSender._payNative function in order to allow for batch sending of messages
+     * @dev Without the override, the OAppSender._payNative would revert on the second message due to a
+     *      failed conditional checking if msg.value is greater than or equal to the native fee. Instead,
+     *      we should check if the balance of the contract is greater than or equal to the native fee
+     * @param _nativeFee The native fee to pay
+     * @return nativeFee The amount of native fee paid
+     */
+    function _payNative(
+        uint256 _nativeFee
+    ) internal view override returns (uint256 nativeFee) {
+        uint256 balance = address(this).balance;
+        if (balance < _nativeFee) revert NotEnoughNative(balance);
+        return _nativeFee;
+    }
+
+    /**
      * @notice Decodes the encoded data for the yield update message types
      * @param encodedData The encoded data to decode
      */
@@ -283,4 +304,6 @@ contract StakeUpMessenger is IStakeUpMessenger, OApp {
             (uint256, uint256)
         );
     }
+
+    receive() external payable {}
 }


### PR DESCRIPTION
# Description

`_payNative` within LayerZero's `OApp` assumes that `msg.value` only contains the exact fee required for sending a single cross chain message. This is a problem in the current implementation of `StakeUpMessenger::_batchSend`  as we need to send multiple messages. In order to solve this and still be able to refund all unused fees to users this PR implements the following changes to support proper cross-chain messages.

**Changes Made:**
- Change the input parameter for the `_lzSend` call within `StakeUpMessenger::_batchSend` from `refundRecipient` to the address of `StakeUpMessenger`.
- Add `receive` function to allow the LayerZero endpoint to send unused native token back to the contract.
- At the end of sending all the cross-chain messages, if `providedFee` is greater than 0 the `refundRecipient` will be refunded the remaining of their native token.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
