### PR TITLE
Fix WstUsdcLite event typo

### DIFF
--- a/src/interfaces/IWstUsdcLite.sol
+++ b/src/interfaces/IWstUsdcLite.sol
@@ -12,7 +12,7 @@ interface IWstUsdcLite {
     event StUsdcWrapped(address indexed user, uint256 stUsdcAmount, uint256 wstUsdcAmount);
 
     /// @notice Emitted when wstUsdc is unwrapped to stUsdc
-    event WtTBYUnwrapped(address indexed user, uint256 wstUsdcAmount, uint256 stUsdcAmount);
+    event WstUsdcUnwrapped(address indexed user, uint256 wstUsdcAmount, uint256 stUsdcAmount);
 
     // =================== Functions ===================
 

--- a/src/token/WstUsdcLite.sol
+++ b/src/token/WstUsdcLite.sol
@@ -43,7 +43,7 @@ contract WstUsdcLite is IWstUsdcLite, ERC20 {
 
         _burn(msg.sender, wstUsdcAmount);
         StUsdcLite(address(_stUsdc)).transferShares(msg.sender, wstUsdcAmount);
-        emit WtTBYUnwrapped(msg.sender, wstUsdcAmount, stUsdcAmount);
+        emit WstUsdcUnwrapped(msg.sender, wstUsdcAmount, stUsdcAmount);
     }
 
     /// @inheritdoc IWstUsdcLite


### PR DESCRIPTION
# Description

Within `WstUsdcLite` there is an event emitted during the unwrapping process that was not properly named. 

This PR addresses this issue changing name of the `WtTBYUnwrapped` event to `WstUsdcUnwrapped`.

## Type of change

- [ ] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
