### PR TITLE
Updated Mint Reward Mechanism

### DIFF
--- a/src/token/StUsdc.sol
+++ b/src/token/StUsdc.sol
@@ -378,7 +378,8 @@ contract StUsdc is IStUsdc, StUsdcLite, ReentrancyGuard, ERC1155TokenReceiver {
      */
     function _calculateRewards(IBloomPool pool, uint256 tbyId, uint256 amountMinted) internal view returns (uint256) {
         IBloomPool.TbyMaturity memory maturity = pool.tbyMaturity(tbyId);
-        uint256 percentMature = (block.timestamp - maturity.start).divWad(maturity.end - maturity.start);
+        uint256 timeElapsed = block.timestamp - maturity.start;
+        uint256 percentMature = timeElapsed.divWad(maturity.end - maturity.start);
         percentMature = percentMature >= Math.WAD ? Math.WAD : percentMature;
         uint256 rewardsAbandoned = amountMinted.mulWad(percentMature);
         return amountMinted - rewardsAbandoned;

--- a/src/token/StUsdc.sol
+++ b/src/token/StUsdc.sol
@@ -121,11 +121,12 @@ contract StUsdc is IStUsdc, StUsdcLite, ReentrancyGuard, ERC1155TokenReceiver {
         require(!pool.isTbyRedeemable(tbyId), Errors.RedeemableTbyNotAllowed());
         // If the token is a TBY, we need to get the current exchange rate of the token
         //     to accurately calculate the amount of stUsdc to mint.
-        amountMinted = pool.getRate(tbyId).mulWad(amount) * _scalingFactor;
-        _deposit(amountMinted);
+        uint256 scaledAmount = amount * _scalingFactor;
+        amountMinted = pool.getRate(tbyId).mulWad(scaledAmount);
 
+        _deposit(amountMinted);
         // Calculate & mint SUP mint rewards to users.
-        _mintRewards(pool, tbyId, amountMinted);
+        _mintRewards(pool, tbyId, scaledAmount);
 
         emit TbyDeposited(msg.sender, tbyId, amount, amountMinted);
         _tby.safeTransferFrom(msg.sender, address(this), tbyId, amount, "");

--- a/tests/foundry/fuzz/StUsdcFuzz.t.sol
+++ b/tests/foundry/fuzz/StUsdcFuzz.t.sol
@@ -73,7 +73,7 @@ contract StUsdcFuzzTest is StUsdcSetup {
         // mint TBY to alice
         (uint256 id,) = bloomPool.swapIn(bloomLenders, totalCollateral);
         // Skip to a new price
-        _skipAndUpdatePrice(30 days, 115e8, 2);
+        _skipAndUpdatePrice(90 days, 115e8, 2);
 
         assertEq(tby.balanceOf(alice, id), amount);
 
@@ -87,7 +87,8 @@ contract StUsdcFuzzTest is StUsdcSetup {
         assertEq(stUsdc.balanceOf(alice), expectedStUsdc);
 
         // Validate that the user received mint rewards if they deposited 200M or less
-        uint256 expectedSup = (expectedStUsdc < 200_000_000e18) ? expectedStUsdc : 200_000_000e18;
+        // Since 50% of the TBYs maturity has passed, the user should have received 50% of the mint rewards
+        uint256 expectedSup = ((expectedStUsdc / 2) < 200_000_000e18) ? (expectedStUsdc / 2) : 200_000_000e18;
         assertEq(supToken.balanceOf(alice), expectedSup);
     }
 

--- a/tests/foundry/unit/StUsdcUnit.t.sol
+++ b/tests/foundry/unit/StUsdcUnit.t.sol
@@ -93,7 +93,7 @@ contract StUsdcUnitTest is StUsdcSetup {
         // Deposit 25% of TBYs halfway through its maturity
         _skipAndUpdatePrice(90 days, 105e8, 2);
 
-        uint256 expectedHalfWayBalance = 25e18 + (25e18 / 2e18);
+        uint256 expectedHalfWayBalance = 25e18 + uint256(25e18).divWad(2e18);
         vm.prank(alice);
         stUsdc.depositTby(id, 25e6);
         assertEq(supToken.balanceOf(alice), expectedHalfWayBalance);

--- a/tests/foundry/unit/StUsdcUnit.t.sol
+++ b/tests/foundry/unit/StUsdcUnit.t.sol
@@ -93,7 +93,7 @@ contract StUsdcUnitTest is StUsdcSetup {
         // Deposit 25% of TBYs halfway through its maturity
         _skipAndUpdatePrice(90 days, 105e8, 2);
 
-        uint256 expectedHalfWayBalance = 25e18 + ((25e18 * 1.05e18) / 2e18);
+        uint256 expectedHalfWayBalance = 25e18 + (25e18 / 2e18);
         vm.prank(alice);
         stUsdc.depositTby(id, 25e6);
         assertEq(supToken.balanceOf(alice), expectedHalfWayBalance);

--- a/tests/foundry/unit/StUsdcUnit.t.sol
+++ b/tests/foundry/unit/StUsdcUnit.t.sol
@@ -93,7 +93,7 @@ contract StUsdcUnitTest is StUsdcSetup {
         // Deposit 25% of TBYs halfway through its maturity
         _skipAndUpdatePrice(90 days, 105e8, 2);
 
-        uint256 expectedHalfWayBalance = 25e18 + uint256(25e18).divWad(2e18);
+        uint256 expectedHalfWayBalance = 25e18.divWad(2e18);
         vm.prank(alice);
         stUsdc.depositTby(id, 25e6);
         assertEq(supToken.balanceOf(alice), expectedHalfWayBalance);


### PR DESCRIPTION
# Description

Currently users can game the mint reward system by depositing TBYs at the end of their maturity, claiming full mint rewards of `SUP`, then withdraw immediately, thus stealing `SUP` rewards without contributing to protocol TVL. In order to prevent users from gaming this system a time weighted penalty has been added to the reward calculation on TBY deposits. 

The new system works by having a penalty that is linearly scales as TBY maturity gets closer. If a users deposits their TBY immediately after its minted then they will receive the `SUP` rewards at a 1:1 `stUSDC` mint size to `SUP` reward size. As time goes on this ratio changes such that the amount of `SUP` a user receives linearly decreases. 

Example:
0 time elapsed from TBY mint:
- TBY deposit in 100 USD value = 100 SUP rewards

TBY is half matured:
- TBY deposit in 100 USD value = 50 SUP rewards

TBY is fully matured:
- TBY deposit in 100 USD value = 0 SUP rewards 

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
