### PR TITLE
wstUsdc peer bridge addresses moved to bytes32 variables in order to …

### DIFF
--- a/src/interfaces/IWstUsdcBridge.sol
+++ b/src/interfaces/IWstUsdcBridge.sol
@@ -9,6 +9,9 @@ import {IControllerBase} from "./IControllerBase.sol";
 interface IWstUsdcBridge is ILayerZeroSettings, IControllerBase {
     // =================== Events ===================
 
+    /// @notice Emitted when a new bridge is set for WstUsdc
+    event WstUsdcBridgeSet(uint32 eid, bytes32 bridgeAddress);
+
     /// @notice Emitted when wstUsdc is bridged sent to another chain
     event WstUsdcBridged(uint32 srcEid, uint32 dstEid, uint256 wstUsdcAmount);
 
@@ -16,37 +19,37 @@ interface IWstUsdcBridge is ILayerZeroSettings, IControllerBase {
 
     /**
      * @notice Bridges wstUsdc to another chain using LayerZero
-     * @param destinationAddress The address to send the bridged wstUsdc to
-     * @param wstUsdcAmount Amount of wstUsdc to bridge
      * @param dstEid The destination LayerZero Endpoint ID
+     * @param destinationAddress The address to send the bridged wstUsdc to (casted to bytes32)
+     * @param wstUsdcAmount Amount of wstUsdc to bridge
      * @param settings Configuration settings for bridging using LayerZero
      * @return bridgingReceipt LzBridgeReceipt Receipts for bridging using LayerZero
      */
     function bridgeWstUsdc(
-        address destinationAddress,
-        uint256 wstUsdcAmount,
         uint32 dstEid,
+        bytes32 destinationAddress,
+        uint256 wstUsdcAmount,
         LzSettings calldata settings
     ) external payable returns (LzBridgeReceipt memory bridgingReceipt);
 
     /**
      * @notice Sets the wstUsdc bridge address for the given endpoint ID
      * @param eid The LayerZero Endpoint ID
-     * @param bridgeAddress The address of the wstUsdc bridge contract
+     * @param bridgeAddress The address of the wstUsdc bridge contract (casted to bytes32)
      */
-    function setWstUsdcBridge(uint32 eid, address bridgeAddress) external;
+    function setWstUsdcBridge(uint32 eid, bytes32 bridgeAddress) external;
 
     /**
      * @notice Quotes the fee for bridging wstUsdc
      * @param dstEid The destination LayerZero Endpoint ID
-     * @param destinationAddress The address to send the bridged wstUsdc to
+     * @param destinationAddress The address to send the bridged wstUsdc to (casted to bytes32)
      * @param wstUsdcAmount The amount of wstUsdc being bridged
      * @param options The executor options for calling `bridgeWstUsdc`
      * @return fee The messaging fee for bridging wstUsdc
      */
     function quoteBridgeWstUsdc(
         uint32 dstEid,
-        address destinationAddress,
+        bytes32 destinationAddress,
         uint256 wstUsdcAmount,
         bytes calldata options
     ) external view returns (MessagingFee memory fee);
@@ -60,7 +63,7 @@ interface IWstUsdcBridge is ILayerZeroSettings, IControllerBase {
     /**
      * @notice Returns the address of the wstUsdc bridge contract for the given endpoint ID
      * @param eid The LayerZero Endpoint ID
-     * @return The address of the wstUsdc bridge contract
+     * @return The address of the wstUsdc bridge contract (casted to bytes32)
      */
-    function bridgeByEid(uint32 eid) external view returns (address);
+    function bridgeByEid(uint32 eid) external view returns (bytes32);
 }

--- a/src/messaging/BridgeOperator.sol
+++ b/src/messaging/BridgeOperator.sol
@@ -67,10 +67,10 @@ contract BridgeOperator is Ownable2Step {
      * @notice Sets the wstUsdc bridge address for the given endpoint ID
      * @dev Can only be called by the owner
      * @param eid The LayerZero Endpoint ID
-     * @param bridge The address of the wstUsdc bridge contract
+     * @param bridge The address of the wstUsdc bridge contract (casted to bytes32)
      */
-    function setWstUsdcBridge(uint32 eid, address bridge) external onlyOwner {
-        require(bridge != address(0), Errors.ZeroAddress());
+    function setWstUsdcBridge(uint32 eid, bytes32 bridge) external onlyOwner {
+        require(bridge != bytes32(0), Errors.ZeroAddress());
         (,, address wstUsdcBridge,) = _decodeContracts();
         IWstUsdcBridge(wstUsdcBridge).setWstUsdcBridge(eid, bridge);
     }

--- a/tests/foundry/CrossChainSetup.t.sol
+++ b/tests/foundry/CrossChainSetup.t.sol
@@ -113,7 +113,7 @@ abstract contract CrossChainSetup is StUsdcSetup {
                     address(StUsdc(stUsdcAddrs[j]).keeper()).addressToBytes32()
                 ];
                 operator.setPeers(uint32(j + 1), peers);
-                operator.setWstUsdcBridge(uint32(j + 1), wstUsdcBridgeAddrs[j]);
+                operator.setWstUsdcBridge(uint32(j + 1), wstUsdcBridgeAddrs[j].addressToBytes32());
             }
         }
     }

--- a/tests/foundry/unit/CrossChainUnitTest.t.sol
+++ b/tests/foundry/unit/CrossChainUnitTest.t.sol
@@ -221,7 +221,8 @@ contract CrossChainUnitTest is CrossChainSetup {
         msgOptions =
             OptionsBuilder.newOptions().addExecutorLzReceiveOption(200000, 0).addExecutorLzComposeOption(0, 200000, 0);
 
-        MessagingFee memory fee = wstUsdcBridge.quoteBridgeWstUsdc(dstChainId, user, amount, msgOptions);
+        MessagingFee memory fee =
+            wstUsdcBridge.quoteBridgeWstUsdc(dstChainId, user.addressToBytes32(), amount, msgOptions);
         ILayerZeroSettings.LzSettings memory settings = ILayerZeroSettings.LzSettings({
             options: msgOptions,
             fee: MessagingFee({nativeFee: fee.nativeFee, lzTokenFee: 0}),
@@ -230,7 +231,9 @@ contract CrossChainUnitTest is CrossChainSetup {
 
         wstUsdc.approve(address(wstUsdcBridge), amount);
         deal(user, settings.fee.nativeFee);
-        receipt = wstUsdcBridge.bridgeWstUsdc{value: settings.fee.nativeFee}(user, amount, dstChainId, settings);
+        receipt = wstUsdcBridge.bridgeWstUsdc{value: settings.fee.nativeFee}(
+            dstChainId, user.addressToBytes32(), amount, settings
+        );
         vm.stopPrank();
     }
 


### PR DESCRIPTION
# Description

Currently within StakeUp, peer `WstUsdcBridge`s and recipients of bridged `wstUsdc` are registered as `address` types. This limits bridging to blockchains that have 160 bit addresses, thus excluding chains such as Solana, Sui, Movement and Aptos. In order to support such networks this PR updates registration of recipients and peer bridges to `bytes32` in order to support all representation of wallet addresses.

## Type of change

- [x] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
